### PR TITLE
Upgrade colors library to latest 0.7.0

### DIFF
--- a/chords-core/build.gradle
+++ b/chords-core/build.gradle
@@ -23,7 +23,7 @@ kotlin {
 
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1"
 
-                api "com.chrynan.colors:colors-core:0.3.0"
+                api "com.chrynan.colors:colors-core:0.7.0"
             }
         }
         all {


### PR DESCRIPTION
This upgrades the colors library to the latest version (0.7.0), fixing a crash-inducing bug from that library.  Fixes #10 